### PR TITLE
[G2M] devops/gltich - update install instruction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem "pg", "~> 1.2"
 gem "rerun", "~> 0.13.1", :group => :development
 
 gem "sinatra-contrib", "~> 2.1"
+
+gem "thin", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    daemons (1.3.1)
+    eventmachine (1.2.7)
     ffi (1.15.0)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -29,6 +31,10 @@ GEM
       rack-protection (= 2.1.0)
       sinatra (= 2.1.0)
       tilt (~> 2.0)
+    thin (1.8.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     tilt (2.0.10)
 
 PLATFORMS
@@ -40,6 +46,7 @@ DEPENDENCIES
   rerun (~> 0.13.1)
   sinatra (~> 2.1)
   sinatra-contrib (~> 2.1)
+  thin (~> 1.8)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ You can also opt to develop using your local environment. Ruby v2.3+ is recommen
 
 ## Notes on working through the problems
 
-Make sure any additional Python level dependencies are properly added in `Pipfile`. We encourage a healthy mixture of your own implementations, and good choices of existing open-source libraries/tools. We will comment in the problems to indicate which ones cannot be solved purely through an off-the-shelf solution.
+We encourage a healthy mixture of your own implementations, and good choices of existing open-source libraries/tools. We will comment in the problems to indicate which ones cannot be solved purely through an off-the-shelf solution.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Glitch is recommended:
 2. Populate `.env` file with the environment variables given in the problem set we send to you through email
 3. Click on `Show Live` and you should see `Welcome to EQ Works 😎`
 
-You can also opt to develop using your local environment. Ruby v2.3+ is required.
+You can also opt to develop using your local environment. Ruby v2.3+ is recommended.
 
-### Notes on working through the problems
+## Notes on working through the problems
 
 Make sure any additional Python level dependencies are properly added in `Pipfile`. We encourage a healthy mixture of your own implementations, and good choices of existing open-source libraries/tools. We will comment in the problems to indicate which ones cannot be solved purely through an off-the-shelf solution.

--- a/glitch.json
+++ b/glitch.json
@@ -1,5 +1,5 @@
 {
-  "install": "bundle install --path ./.data/bundler --without=development",
+  "install": "bundle install --without=development",
   "start": "bundle exec ruby app.rb",
   "watch": {
     "install": {


### PR DESCRIPTION
this PR contains the `thin` server gem necessary for glitch to run since it doesn't support the default `rack` server that sinatra uses. clicking on remix button only imports from the main branch so you'll need to manually add `thin` inside glitch after importing, using its terminal:

```shell
$ bundle add thin
```